### PR TITLE
root: Do not use internal xrootd

### DIFF
--- a/env/dev/sim_no-threads.yaml
+++ b/env/dev/sim_no-threads.yaml
@@ -1,9 +1,9 @@
 spack:
   definitions:
     - when: platform == 'linux'
-      root: [root@6.18.04+fortran+gdml+http+pythia6+pythia8+vc~vdt~python~tmva]
+      root: [root@6.18.04+fortran+gdml+http+pythia6+pythia8+vc~vdt+python+tmva ^mesa~llvm]
     - when: platform == 'darwin'
-      root: [root@6.18.04+fortran+gdml+http+pythia6+pythia8+vc~vdt~python~tmva+aqua]
+      root: [root@6.18.04+fortran+gdml+http+pythia6+pythia8+vc~vdt+python+tmva+aqua]
   specs:
     - pcre+jit
     - pythia6@428-alice1
@@ -11,9 +11,10 @@ spack:
     - pythia8@8301
     - geant4@10.05.p01~qt~vecgeom~opengl~x11~motif~data~clhep~threads
     - $root
-    - geant3@v2-7_fairsoft
-    - vgm@4-6
-    - geant4_vmc@4-0-p1
+    - vmc@1-0
+    - geant3@v3-0_fairsoft
+    - vgm@4-7
+    - geant4_vmc@5-0
     - fairroot@dev+sim
   concretization: together
   view: false

--- a/env/dev/sim_threads.yaml
+++ b/env/dev/sim_threads.yaml
@@ -1,9 +1,9 @@
 spack:
   definitions:
     - when: platform == 'linux'
-      root: [root@6.18.04+fortran+gdml+http+pythia6+pythia8+vc~vdt~python~tmva]
+      root: [root@6.18.04+fortran+gdml+http+pythia6+pythia8+vc~vdt+python+tmva ^mesa~llvm]
     - when: platform == 'darwin'
-      root: [root@6.18.04+fortran+gdml+http+pythia6+pythia8+vc~vdt~python~tmva+aqua]
+      root: [root@6.18.04+fortran+gdml+http+pythia6+pythia8+vc~vdt+python+tmva+aqua]
   specs:
     - pcre+jit
     - pythia6@428-alice1
@@ -11,9 +11,10 @@ spack:
     - pythia8@8301
     - geant4@10.05.p01~qt~vecgeom~opengl~x11~motif~data~clhep+threads
     - $root
-    - geant3@v2-7_fairsoft
-    - vgm@4-6
-    - geant4_vmc@4-0-p1
+    - vmc@1-0
+    - geant3@v3-0_fairsoft
+    - vgm@4-7
+    - geant4_vmc@5-0
     - fairroot@dev+sim
   concretization: together
   view: false

--- a/env/dev/sim_threads_no-x_no-opengl.yaml
+++ b/env/dev/sim_threads_no-x_no-opengl.yaml
@@ -1,9 +1,9 @@
 spack:
   definitions:
     - when: platform == 'linux'
-      root: [root@6.18.04+fortran+gdml+http+pythia6+pythia8+vc~vdt~x~opengl~python~tmva]
+      root: [root@6.18.04+fortran+gdml+http+pythia6+pythia8+vc~vdt~x~opengl+python+tmva]
     - when: platform == 'darwin'
-      root: [root@6.18.04+fortran+gdml+http+pythia6+pythia8+vc~vdt~x~opengl~python~tmva+aqua]
+      root: [root@6.18.04+fortran+gdml+http+pythia6+pythia8+vc~vdt~x~opengl+python+tmva+aqua]
   specs:
     - pcre+jit
     - pythia6@428-alice1
@@ -11,9 +11,10 @@ spack:
     - pythia8@8301
     - geant4@10.05.p01~qt~vecgeom~opengl~x11~motif~data~clhep+threads
     - $root
-    - geant3@v2-7_fairsoft
-    - vgm@4-6
-    - geant4_vmc@4-0-p1
+    - vmc@1-0
+    - geant3@v3-0_fairsoft
+    - vgm@4-7
+    - geant4_vmc@5-0
     - fairroot@dev+sim
   concretization: together
   view: false

--- a/packages/fairroot/package.py
+++ b/packages/fairroot/package.py
@@ -40,6 +40,8 @@ class Fairroot(CMakePackage):
     # Dependencies for dev version
     depends_on('boost@1.68.0: cxxstd=11 +container')
 
+    depends_on('vmc', when='@dev')
+
     depends_on('geant4', when="+sim")
 
     depends_on('root')
@@ -52,7 +54,7 @@ class Fairroot(CMakePackage):
     depends_on('fairmq@1.4.3:')
 
 #    depends_on('protobuf@3.4.0')
-#    depends_on('flatbuffers@1.9.0')
+    depends_on('flatbuffers')
 #    depends_on('millepede')
 
     patch('CMake.patch', level=0, when="@18.0.6")
@@ -80,6 +82,8 @@ class Fairroot(CMakePackage):
         self.spec['boost'].prefix))
         options.append('-DBOOST_LIBRARYDIR={0}/lib'.format(
         self.spec['boost'].prefix))
+        options.append('-DFlatbuffers_DIR={0}'.format(
+        self.spec['flatbuffers'].prefix))
         options.append('-DDISABLE_GO=ON')
         options.append('-DBUILD_EXAMPLES=OFF')
         options.append('-DFAIRROOT_MODULAR_BUILD=ON')

--- a/packages/g4emlow/package.py
+++ b/packages/g4emlow/package.py
@@ -16,6 +16,7 @@ class G4emlow(Package):
     version('6.50', sha256='c97be73fece5fb4f73c43e11c146b43f651c6991edd0edf8619c9452f8ab1236')
     version('7.3', sha256='583aa7f34f67b09db7d566f904c54b21e95a9ac05b60e2bfb794efb569dba14e')
     version('7.7', sha256='16dec6adda6477a97424d749688d73e9bd7d0b84d0137a67cf341f1960984663')
+    version('7.9', sha256='4abf9aa6cda91e4612676ce4d2d8a73b91184533aa66f9aad19a53a8c4dc3aff')
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))

--- a/packages/g4ndl/package.py
+++ b/packages/g4ndl/package.py
@@ -13,6 +13,7 @@ class G4ndl(Package):
     homepage = "http://geant4.web.cern.ch"
     url = "http://geant4-data.web.cern.ch/geant4-data/datasets/G4NDL.4.5.tar.gz"
 
+    version('4.6', sha256='9d287cf2ae0fb887a2adce801ee74fb9be21b0d166dab49bcbee9408a5145408')
     version('4.5', 'cba928a520a788f2bc8229c7ef57f83d0934bb0c6a18c31ef05ef4865edcdf8e')
 
     def install(self, spec, prefix):

--- a/packages/g4particlexs/package.py
+++ b/packages/g4particlexs/package.py
@@ -12,8 +12,9 @@ class G4particlexs(Package):
     """Geant4 data files for evaluated particle cross-sections on natural composition
        of elements"""
     homepage = "http://geant4.web.cern.ch"
-    url = "http://geant4-data.web.cern.ch/geant4-data/datasets/G4PARTICLESXS.1.1.tar.gz"
+    url = "http://geant4-data.web.cern.ch/geant4-data/datasets/G4PARTICLEXS.1.1.tar.gz"
 
+    version('2.1', sha256='094d103372bbf8780d63a11632397e72d1191dc5027f9adabaf6a43025520b41')
     version('1.1', '100a11c9ed961152acfadcc9b583a9f649dda4e48ab314fcd4f333412ade9d62')
 
     def install(self, spec, prefix):

--- a/packages/g4photonevaporation/package.py
+++ b/packages/g4photonevaporation/package.py
@@ -16,6 +16,7 @@ class G4photonevaporation(Package):
     version('4.3.2', 'd4641a6fe1c645ab2a7ecee09c34e5ea584fb10d63d2838248bfc487d34207c7')
     version('5.2', '83607f8d36827b2a7fca19c9c336caffbebf61a359d0ef7cee44a8bcf3fc2d1f')
     version('5.3', 'd47ababc8cbe548065ef644e9bd88266869e75e2f9e577ebc36bc55bf7a92ec8')
+    version('5.5', sha256='5995dda126c18bd7f68861efde87b4af438c329ecbe849572031ceed8f5e76d7')
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))

--- a/packages/g4radioactivedecay/package.py
+++ b/packages/g4radioactivedecay/package.py
@@ -16,6 +16,7 @@ class G4radioactivedecay(Package):
     version('5.1.1', 'f7a9a0cc998f0d946359f2cb18d30dff1eabb7f3c578891111fc3641833870ae')
     version('5.2', '99c038d89d70281316be15c3c98a66c5d0ca01ef575127b6a094063003e2af5d')
     version('5.3', '5c8992ac57ae56e66b064d3f5cdfe7c2fee76567520ad34a625bfb187119f8c1')
+    version('5.4', sha256='240779da7d13f5bf0db250f472298c3804513e8aca6cae301db97f5ccdcc4a61')
 
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))

--- a/packages/geant3/package.py
+++ b/packages/geant3/package.py
@@ -33,10 +33,12 @@ class Geant3(CMakePackage):
 
     version('v2-5-gcc8', tag='v2-5-gcc8')
     version('v2-7_fairsoft', tag='v2-7_fairsoft')
+    version('v3-0_fairsoft', tag='v3-0_fairsoft')
 
     # FIXME: Add dependencies if required.
     depends_on('cmake', type='build')
-    depends_on("root")
+    depends_on('root')
+    depends_on('vmc', when='@v3-0_fairsoft:')
 
     def cmake_args(self):
         spec = self.spec

--- a/packages/geant4-data/package.py
+++ b/packages/geant4-data/package.py
@@ -14,6 +14,7 @@ class Geant4Data(Package):
     homepage = "http://geant4.cern.ch"
     url      = "http://geant4-data.web.cern.ch/geant4-data/ReleaseNotes/ReleaseNotes4.10.3.html"
 
+    version('10.06', sha256='cc4b1b54cc480961271733c7d64ffe28d06f4ab3bec673885c16251975c3bc9b', expand=False)
     version('10.05', 'd43b9cc4418afe67a7b444727810827a', expand=False)
     version('10.04', 'c49194b96e65ed4527d34d22a9860972', expand=False)
     version('10.03', '2248ad436613897d9fad93bdb99d9446', expand=False)
@@ -61,6 +62,19 @@ class Geant4Data(Package):
     depends_on("g4ensdfstate@2.2", when='@10.05')
     depends_on("g4realsurface@2.1.1", when='@10.05')
     depends_on("g4tendl@1.3.2", when='@10.05')
+    # geant4@10.06
+    depends_on("g4ndl@4.6", when='@10.06')
+    depends_on("g4emlow@7.9", when='@10.06')
+    depends_on("g4photonevaporation@5.5", when='@10.06')
+    depends_on("g4radioactivedecay@5.4", when='@10.06')
+    depends_on("g4saiddata@2.0", when='@10.06')
+    depends_on("g4particlexs@2.1", when='@10.06')
+    depends_on("g4abla@3.1", when='@10.06')
+    depends_on("g4incl@1.0", when='@10.06')
+    depends_on("g4pii@1.3", when='@10.06')
+    depends_on("g4ensdfstate@2.2", when='@10.06')
+    depends_on("g4realsurface@2.1.1", when='@10.06')
+    depends_on("g4tendl@1.3.2", when='@10.06')
 
     # geant4@10.03.p03
 #    depends_on("g4abla@3.0", when='@10.03.p03 ')

--- a/packages/geant4/package.py
+++ b/packages/geant4/package.py
@@ -43,6 +43,7 @@ class Geant4(CMakePackage):
 
     # C++11 support
     depends_on("xerces-c cxxstd=11", when="cxxstd=11")
+    depends_on("clhep@2.4.1.3 cxxstd=11", when="@10.06 cxxstd=11 +clhep")
     depends_on("clhep@2.4.1.0 cxxstd=11", when="@10.05.p01 cxxstd=11 +clhep")
     depends_on("clhep@2.4.0.0 cxxstd=11", when="@10.04.p03 cxxstd=11 +clhep")
     depends_on("clhep@2.4.0.0 cxxstd=11", when="@10.04.p01 cxxstd=11 +clhep")
@@ -52,6 +53,7 @@ class Geant4(CMakePackage):
 
     # C++14 support
     depends_on("xerces-c cxxstd=14", when="cxxstd=14")
+    depends_on("clhep@2.4.1.3 cxxstd=14", when="@10.06 cxxstd=14 +clhep")
     depends_on("clhep@2.4.1.0 cxxstd=14", when="@10.05.p01 cxxstd=14 +clhep")
     depends_on("clhep@2.4.0.0 cxxstd=14", when="@10.04.p03 cxxstd=14 +clhep")
     depends_on("clhep@2.4.0.0 cxxstd=14", when="@10.04.p01 cxxstd=14 +clhep")
@@ -63,6 +65,7 @@ class Geant4(CMakePackage):
     depends_on("xerces-c cxxstd=17", when="cxxstd=17")
     patch('cxx17.patch', when='@:10.03.p99 cxxstd=17')
     patch('cxx17_geant4_10_0.patch', level=1, when='@10.04.00: cxxstd=17 +clhep')
+    depends_on("clhep@2.4.1.3 cxxstd=17", when="@10.06 cxxstd=17 +clhep")
     depends_on("clhep@2.4.1.0 cxxstd=17", when="@10.05.p01 cxxstd=17 +clhep")
     depends_on("clhep@2.4.0.0 cxxstd=17", when="@10.04.p03 cxxstd=17 +clhep")
     depends_on("clhep@2.4.0.0 cxxstd=17", when="@10.04.p01 cxxstd=17 +clhep")
@@ -84,6 +87,7 @@ class Geant4(CMakePackage):
     # this allows external data installations
     # to avoid duplication
 
+    depends_on('geant4-data@10.06', when='@10.06:10.06.p99 ~data')
     depends_on('geant4-data@10.05', when='@10.05.p00:10.05.p99 ~data')
     depends_on('geant4-data@10.04', when='@10.04.p00:10.04.p99 ~data')
     depends_on('geant4-data@10.03', when='@10.03.p03 ~data')

--- a/packages/geant4_vmc/package.py
+++ b/packages/geant4_vmc/package.py
@@ -32,12 +32,14 @@ class Geant4Vmc(CMakePackage):
 
     version('3-6', '01507945dfcc21827628d0eb6b233931')
     version('4-0-p1', 'd7e88a3ef11ea62bec314b5f251c91b1')
+    version('5-0', sha256='9a3820ea4b68b5a0697c340bbbc0972b9c8e4205ceecdd87258a9bdfd249cd8b')
 
     # FIXME: Add dependencies if required.
     depends_on('cmake', type='build')
     depends_on('root')
     depends_on('geant4')
     depends_on('vgm')
+    depends_on('vmc', when='@5-0:')
 
     def cmake_args(self):
         spec = self.spec

--- a/packages/git/package.py
+++ b/packages/git/package.py
@@ -1,0 +1,254 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import sys
+from spack import *
+
+
+class Git(AutotoolsPackage):
+    """Git is a free and open source distributed version control
+    system designed to handle everything from small to very large
+    projects with speed and efficiency.
+    """
+
+    homepage = "http://git-scm.com"
+    url      = "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.12.0.tar.gz"
+
+    # In order to add new versions here, add a new list entry with:
+    # * version: {version}
+    # * sha256: the sha256sum of the git-{version}.tar.gz
+    # * sha256_manpages: the sha256sum of the corresponding manpage from
+    #       https://www.kernel.org/pub/software/scm/git/git-manpages-{version}.tar.gz
+    # You can find the source here: https://mirrors.edge.kernel.org/pub/software/scm/git/sha256sums.asc
+
+    releases = [
+        {
+            'version': '2.21.0',
+            'sha256': '85eca51c7404da75e353eba587f87fea9481ba41e162206a6f70ad8118147bee',
+            'sha256_manpages': '14c76ebb4e31f9e55cf5338a04fd3a13bced0323cd51794ccf45fc74bd0c1080'
+        },
+        {
+            'version': '2.20.1',
+            'sha256': 'edc3bc1495b69179ba4e272e97eff93334a20decb1d8db6ec3c19c16417738fd',
+            'sha256_manpages': 'e9c123463abd05e142defe44a8060ce6e9853dfd8c83b2542e38b7deac4e6d4c'
+        },
+        {
+            'version': '2.19.2',
+            'sha256': 'db893ad69c9ac9498b09677c5839787eba2eb3b7ef2bc30bfba7e62e77cf7850',
+            'sha256_manpages': '60334ecd59ee10319af4a7815174d10991d1afabacd3b3129d589f038bf25542'
+        },
+        {
+            'version': '2.19.1',
+            'sha256': 'ec4dc96456612c65bf6d944cee9ac640145ec7245376832b781cb03e97cbb796',
+            'sha256_manpages': 'bd27f58dc90a661e3080b97365eb7322bfa185de95634fc59d98311925a7d894'
+        },
+        {
+            'version': '2.18.0',
+            'sha256': '94faf2c0b02a7920b0b46f4961d8e9cad08e81418614102898a55f980fa3e7e4',
+            'sha256_manpages': '6cf38ab3ad43ccdcd6a73ffdcf2a016d56ab6b4b240a574b0bb96f520a04ff55'
+        },
+        {
+            'version': '2.17.1',
+            'sha256': 'ec6452f0c8d5c1f3bcceabd7070b8a8a5eea11d4e2a04955c139b5065fd7d09a',
+            'sha256_manpages': '9732053c1a618d2576c1751d0249e43702f632a571f84511331882beb360677d'
+        },
+        {
+            'version': '2.17.0',
+            'sha256': '7a0cff35dbb14b77dca6924c33ac9fe510b9de35d5267172490af548ec5ee1b8',
+            'sha256_manpages': '41b58c68e90e4c95265c75955ddd5b68f6491f4d57b2f17c6d68e60bbb07ba6a'
+        },
+        {
+            'version': '2.15.1',
+            'sha256': '85fca8781a83c96ba6db384cc1aa6a5ee1e344746bafac1cbe1f0fe6d1109c84',
+            'sha256_manpages': '472454c494c9a7f50ad38060c3eec372f617de654b20f3eb3be59fc17a683fa1',
+        },
+        {
+            'version': '2.14.1',
+            'sha256': '01925349b9683940e53a621ee48dd9d9ac3f9e59c079806b58321c2cf85a4464',
+            'sha256_manpages': '8c5810ce65d44cd333327d3a115c5b462712a2f81225d142e07bd889ad8dc0e0',
+        },
+        {
+            'version': '2.13.0',
+            'sha256': '9f2fa8040ebafc0c2caae4a9e2cb385c6f16c0525bcb0fbd84938bc796372e80',
+            'sha256_manpages': 'e764721796cad175a4cf9a4afe7fb4c4fc57582f6f9a6e214239498e0835355b',
+        },
+        {
+            'version': '2.12.2',
+            'sha256': 'd9c6d787a24670d7e5100db2367c250ad9756ef8084fb153a46b82f1d186f8d8',
+            'sha256_manpages': '6e7ed503f1190734e57c9427df356b42020f125fa36ab0478777960a682adf50',
+        },
+        {
+            'version': '2.12.1',
+            'sha256': '65d62d10caf317fc1daf2ca9975bdb09dbff874c92d24f9529d29a7784486b43',
+            'sha256_manpages': '35e46b8acd529ea671d94035232b1795919be8f3c3a363ea9698f1fd08d7d061',
+        },
+        {
+            'version': '2.12.0',
+            'sha256': '882f298daf582a07c597737eb4bbafb82c6208fe0e73c047defc12169c221a92',
+            'sha256_manpages': '1f7733a44c59f9ae8dd321d68a033499a76c82046025cc2a6792299178138d65',
+        },
+        {
+            'version': '2.11.1',
+            'sha256': 'a1cdd7c820f92c44abb5003b36dc8cb7201ba38e8744802399f59c97285ca043',
+            'sha256_manpages': 'ee567e7b0f95333816793714bb31c54e288cf8041f77a0092b85e62c9c2974f9',
+        },
+        {
+            'version': '2.11.0',
+            'sha256': 'd3be9961c799562565f158ce5b836e2b90f38502d3992a115dfb653d7825fd7e',
+            'sha256_manpages': '437a0128acd707edce24e1a310ab2f09f9a09ee42de58a8e7641362012dcfe22',
+        },
+        {
+            'version': '2.9.3',
+            'sha256': 'a252b6636b12d5ba57732c8469701544c26c2b1689933bd1b425e603cbb247c0',
+            'sha256_manpages': '8ea1a55b048fafbf0c0c6fcbca4b5b0f5e9917893221fc7345c09051d65832ce',
+        },
+        {
+            'version': '2.9.2',
+            'sha256': '3cb09a3917c2d8150fc1708f3019cf99a8f0feee6cd61bba3797e3b2a85be9dc',
+            'sha256_manpages': 'ac5c600153d1e4a1c6494e250cd27ca288e7667ad8d4ea2f2386f60ba1b78eec',
+        },
+        {
+            'version': '2.9.1',
+            'sha256': 'c2230873bf77f93736473e6a06501bf93eed807d011107de6983dc015424b097',
+            'sha256_manpages': '324f5f173f2bd50b0102b66e474b81146ccc078d621efeb86d7f75e3c1de33e6',
+        },
+        {
+            'version': '2.9.0',
+            'sha256': 'bff7560f5602fcd8e37669e0f65ef08c6edc996e4f324e4ed6bb8a84765e30bd',
+            'sha256_manpages': '35ba69a8560529aa837e395a6d6c8d42f4d29b40a3c1cc6e3dc69bb1faadb332',
+        },
+        {
+            'version': '2.8.4',
+            'sha256': '626e319f8a24fc0866167ea5f6bf3e2f38f69d6cb2e59e150f13709ca3ebf301',
+            'sha256_manpages': '953a8eadaf4ae96dbad2c3ec12384c677416843917ef83d94b98367ffd55afc0',
+        },
+        {
+            'version': '2.8.3',
+            'sha256': '2dad50c758339d6f5235309db620e51249e0000ff34aa2f2acbcb84c2123ed09',
+            'sha256_manpages': '2dad50c758339d6f5235309db620e51249e0000ff34aa2f2acbcb84c2123ed09',
+        },
+        {
+            'version': '2.8.2',
+            'sha256': 'a029c37ee2e0bb1efea5c4af827ff5afdb3356ec42fc19c1d40216d99e97e148',
+            'sha256_manpages': '82d322211aade626d1eb3bcf3b76730bfdd2fcc9c189950fb0a8bdd69c383e2f',
+        },
+        {
+            'version': '2.8.1',
+            'sha256': 'cfc66324179b9ed62ee02833f29d39935f4ab66874125a3ab9d5bb9055c0cb67',
+            'sha256_manpages': 'df46de0c172049f935cc3736361b263c5ff289b77077c73053e63ae83fcf43f4',
+        },
+        {
+            'version': '2.8.0',
+            'sha256': '2c6eee5506237e0886df9973fd7938a1b2611ec93d07f64ed3447493ebac90d1',
+            'sha256_manpages': '2c48902a69df3bec3b8b8f0350a65fd1b662d2f436f0e64d475ecd1c780767b6',
+        },
+        {
+            'version': '2.7.3',
+            'sha256': '30d067499b61caddedaf1a407b4947244f14d10842d100f7c7c6ea1c288280cd',
+            'sha256_manpages': '84b487c9071857ab0f15f11c4a102a583d59b524831cda0dc0954bd3ab73920b',
+        },
+        {
+            'version': '2.7.1',
+            'sha256': 'b4ab42798b7fb038eaefabb0c32ce9dbde2919103e5e2a35adc35dd46258a66f',
+            'sha256_manpages': '0313cf4d283336088883d8416692fb6c547512233e11dbf06e5b925b7e762d61',
+        },
+    ]
+
+    for release in releases:
+        version(release['version'], sha256=release['sha256'])
+        resource(
+            name='git-manpages',
+            url="https://www.kernel.org/pub/software/scm/git/git-manpages-{0}.tar.gz".format(
+                release['version']),
+            sha256=release['sha256_manpages'],
+            placement='git-manpages',
+            when='@{0}'.format(release['version']))
+
+    variant('tcltk', default=False,
+            description='Gitk: provide Tcl/Tk in the run environment')
+
+    depends_on('curl')
+    depends_on('expat')
+    depends_on('gettext')
+    depends_on('libiconv')
+    depends_on('libidn2')
+    depends_on('openssl')
+    depends_on('pcre', when='@:2.13')
+    depends_on('pcre+jit', when='@2.14:')
+    depends_on('perl')
+    depends_on('zlib')
+
+    depends_on('autoconf', type='build')
+    depends_on('automake', type='build')
+    depends_on('libtool',  type='build')
+    depends_on('m4',       type='build')
+    depends_on('tk',       type=('build', 'link'), when='+tcltk')
+
+    # See the comment in setup_environment re EXTLIBS.
+    def patch(self):
+        filter_file(r'^EXTLIBS =$',
+                    '#EXTLIBS =',
+                    'Makefile')
+
+    def setup_environment(self, spack_env, run_env):
+        # We use EXTLIBS rather than LDFLAGS so that git's Makefile
+        # inserts the information into the proper place in the link commands
+        # (alongside the # other libraries/paths that configure discovers).
+        # LDFLAGS is inserted *before* libgit.a, which requires libintl.
+        # EXTFLAGS is inserted *after* libgit.a.
+        # This depends on the patch method above, which keeps the Makefile
+        # from stepping on the value that we pass in via the environment.
+        #
+        # The test avoids failures when git is an external package.
+        # In that case the node in the DAG gets truncated and git DOES NOT
+        # have a gettext dependency.
+        if 'gettext' in self.spec:
+            spack_env.append_flags('EXTLIBS', '-L{0} -lintl'.format(
+                self.spec['gettext'].prefix.lib))
+            spack_env.append_flags('CFLAGS', '-I{0}'.format(
+                self.spec['gettext'].prefix.include))
+
+    def configure_args(self):
+        spec = self.spec
+
+        configure_args = [
+            '--with-curl={0}'.format(spec['curl'].prefix),
+            '--with-expat={0}'.format(spec['expat'].prefix),
+            '--with-iconv={0}'.format(spec['libiconv'].prefix),
+            '--with-libpcre={0}'.format(spec['pcre'].prefix),
+            '--with-openssl={0}'.format(spec['openssl'].prefix),
+            '--with-perl={0}'.format(spec['perl'].command.path),
+            '--with-zlib={0}'.format(spec['zlib'].prefix),
+        ]
+
+        if '+tcltk' in self.spec:
+            configure_args.append('--with-tcltk={0}'.format(
+                self.spec['tk'].prefix.bin.wish))
+        else:
+            configure_args.append('--without-tcltk')
+
+        return configure_args
+
+    @run_after('configure')
+    def filter_rt(self):
+        if sys.platform == 'darwin':
+            # Don't link with -lrt; the system has no (and needs no) librt
+            filter_file(r' -lrt$', '', 'Makefile')
+
+    def check(self):
+        make('test')
+
+    @run_after('install')
+    def install_completions(self):
+        install_tree('contrib/completion', self.prefix.share)
+
+    @run_after('install')
+    def install_manpages(self):
+        prefix = self.prefix
+
+        with working_dir('git-manpages'):
+            install_tree('man1', prefix.share.man.man1)
+            install_tree('man5', prefix.share.man.man5)
+            install_tree('man7', prefix.share.man.man7)

--- a/packages/root/opengl_glu_6.18.patch
+++ b/packages/root/opengl_glu_6.18.patch
@@ -1,0 +1,16 @@
+--- cmake/modules/SearchInstalledSoftware.cmake	2020-03-10 11:11:32.154852527 +0100
++++ cmake/modules/SearchInstalledSoftware.cmake_new	2020-03-10 11:17:52.285670611 +0100
+@@ -459,6 +459,13 @@
+       set(opengl OFF CACHE BOOL "Disabled because OpenGL (with GLU) not found (${opengl_description})" FORCE)
+     endif()
+   endif()
++  if(OPENGL_GLU_FOUND)
++    get_filename_component(OPENGLU_INCLUDE_DIR ${OPENGL_glu_LIBRARY} DIRECTORY)
++    set(OPENGLU_INCLUDE_DIR ${OPENGLU_INCLUDE_DIR}/../include)
++    Message(STATUS "OPENGLU_INCLUDE_DIR:   " ${OPENGLU_INCLUDE_DIR})
++    set_target_properties(OpenGL::GLU PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
++                          "${OPENGLU_INCLUDE_DIR}")
++  endif()
+ endif()
+ 
+ #---Check for GLEW -------------------------------------------------------------------

--- a/packages/root/package.py
+++ b/packages/root/package.py
@@ -59,12 +59,14 @@ class Root(CMakePackage):
     patch('root7-webgui.patch', level=1, when='@6.16.00')
 
     # Pass X11 include directories to build system when building builtin glew
-    patch('builtin_glew.patch', level=0)
-    patch('builtin_ftgl.patch', level=0)
-    patch('graf3d_gl.patch', level=0)
+    patch('builtin_glew.patch', level=0, when='@:6.16.00')
+    patch('builtin_ftgl.patch', level=0, when='@:6.16.00')
+    patch('graf3d_gl.patch', level=0, when='@:6.16.00')
     patch('graf2d.patch', level=0)
     patch('external_zlib.patch', level=0, when='@6.12.06')
     patch('root6_16_xrootd.patch', level=0, when='@6.16.00')
+
+    patch('opengl_glu_6.18.patch', level=0, when='@6.18.04')
 
     if sys.platform == 'darwin':
         # Resolve non-standard use of uint, _cf_

--- a/packages/root/package.py
+++ b/packages/root/package.py
@@ -329,7 +329,7 @@ class Root(CMakePackage):
             '-Dbuiltin_vc:BOOL=OFF',
             '-Dbuiltin_vdt:BOOL=OFF',
             '-Dbuiltin_veccore:BOOL=OFF',
-            '-Dbuiltin_xrootd:BOOL=ON',
+            '-Dbuiltin_xrootd:BOOL=OFF',
             '-Dbuiltin_zlib:BOOL=OFF'
         ]
 

--- a/packages/vgm/package.py
+++ b/packages/vgm/package.py
@@ -33,6 +33,7 @@ class Vgm(CMakePackage):
     version('4-4', '42fcd9092981120be1aeb6e3872fa1f7')
     version('4-5', 'e5054a39a33dcefcd6a6588efceda7be')
     version('4-6', sha256='6bf0aeef38f357a313e376090b45d3e0713ef9e52ca198075fae8579b8d5a23a')
+    version('4-7', sha256='a5f5588db457dc3e6562d1f7da1707960304560fbb0a261559fa3f112a476aea')
 
     # FIXME: Add dependencies if required.
     depends_on('cmake', type='build')

--- a/packages/vmc/package.py
+++ b/packages/vmc/package.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install vmc
+#
+# You can edit this file again by typing:
+#
+#     spack edit vmc
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+from spack import *
+
+
+class Vmc(CMakePackage):
+    # The Virtual Monte Carlo core library.
+
+    homepage = "https://github.com/vmc-project/vmc"
+    url      = "https://github.com/vmc-project/vmc/archive/v0-1.tar.gz"
+
+    version('1-0', sha256='3da58518b32db1b503082e3205884802a1a263a915071b96e3fd67861db3ca40')
+
+    depends_on('root')


### PR DESCRIPTION
Instead of trying to build the internal xrootd, use the package from spack. The appropiate depends_on already exists.